### PR TITLE
Make Platforms registerListener return dummy value

### DIFF
--- a/src/angular/platform.ts
+++ b/src/angular/platform.ts
@@ -44,6 +44,7 @@ export class PlatformMock {
         instance.version.and.returnValue([]);
         instance.width.and.returnValue(0);
         instance.doc.and.returnValue(document);
+        instance.registerListener.and.returnValue(() => {});
         instance.win.and.returnValue(window);
         instance.getActiveElement.and.returnValue(document['activeElement']);
         instance.raf.and.returnValue(1);


### PR DESCRIPTION
This prevents an exception when running unit tests of components containing floating action buttons. For more details please my [question on stackoverflow](https://stackoverflow.com/questions/45711222/how-to-test-a-floating-action-button-in-ionic2) and the additional answer on the [clickr repo](https://github.com/lathonez/clicker/issues/191#issuecomment-322783829).
