### PR TITLE
Store the ViewControllerMock as a static variable

### DIFF
--- a/src/angular/view-controller.ts
+++ b/src/angular/view-controller.ts
@@ -3,88 +3,93 @@ import {NavParamsMock}        from './nav-params';
 import {NavControllerMock}    from './nav-controller';
 
 export class ViewControllerMock {
+    private static staticInstance: null;
+
     public static instance(): any {
+        if(ViewControllerMock.staticInstance == null) {
+            let instance = jasmine.createSpyObj('ViewController', [
+                'willEnter',
+                'didEnter',
+                'willLeave',
+                'didLeave',
+                'willUnload',
+                'didUnload',
+                'dismiss',
+                'onDidDismiss',
+                'onWillDismiss',
+                'enableBack',
+                'isFirst',
+                'isLast',
+                'pageRef',
+                'getContent',
+                'contentRef',
+                'hasNavbar',
+                'index',
+                'subscribe',
+                'getNav',
+                'getIONContent',
+                'writeReady',
+                'readReady',
+                'setBackButtonText',
+                'showBackButton',
+                '_setHeader',
+                '_setNavbar',
+                '_setNav',
+                '_setInstance',
+                '_setIONContent',
+                '_setContent',
+                '_setContentRef',
+                '_setFooter',
+                '_setIONContentRef'
+            ]);
 
-        let instance = jasmine.createSpyObj('ViewController', [
-            'willEnter',
-            'didEnter',
-            'willLeave',
-            'didLeave',
-            'willUnload',
-            'didUnload',
-            'dismiss',
-            'onDidDismiss',
-            'onWillDismiss',
-            'enableBack',
-            'isFirst',
-            'isLast',
-            'pageRef',
-            'getContent',
-            'contentRef',
-            'hasNavbar',
-            'index',
-            'subscribe',
-            'getNav',
-            'getIONContent',
-            'writeReady',
-            'readReady',
-            'setBackButtonText',
-            'showBackButton',
-            '_setHeader',
-            '_setNavbar',
-            '_setNav',
-            '_setInstance',
-            '_setIONContent',
-            '_setContent',
-            '_setContentRef',
-            '_setFooter',
-            '_setIONContentRef'
-        ]);
+            instance.willEnter.and.returnValue(Observable.of({}));
+            instance.didEnter.and.returnValue(Observable.of({}));
+            instance.willLeave.and.returnValue(Observable.of({}));
+            instance.didLeave.and.returnValue(Observable.of({}));
+            instance.willUnload.and.returnValue(Observable.of({}));
+            instance.didUnload.and.returnValue(Observable.of({}));
+            instance.dismiss.and.returnValue(Promise.resolve());
+            instance.onDidDismiss.and.returnValue(Promise.resolve());
+            instance.onWillDismiss.and.returnValue(Promise.resolve());
+            instance.enableBack.and.returnValue(true);
+            instance.isFirst.and.returnValue(false);
+            instance.isLast.and.returnValue(false);
+            instance.pageRef.and.returnValue({});
+            instance.getContent.and.returnValue({});
+            instance.contentRef.and.returnValue(Promise.resolve());
+            instance.hasNavbar.and.returnValue(true);
+            instance.index.and.returnValue(true);
+            instance.subscribe.and.returnValue(Observable.of({}));
+            instance.getNav.and.returnValue(NavControllerMock.instance());
+            instance.getIONContent.and.returnValue({});
 
-        instance.willEnter.and.returnValue(Observable.of({}));
-        instance.didEnter.and.returnValue(Observable.of({}));
-        instance.willLeave.and.returnValue(Observable.of({}));
-        instance.didLeave.and.returnValue(Observable.of({}));
-        instance.willUnload.and.returnValue(Observable.of({}));
-        instance.didUnload.and.returnValue(Observable.of({}));
-        instance.dismiss.and.returnValue(Promise.resolve());
-        instance.onDidDismiss.and.returnValue(Promise.resolve());
-        instance.onWillDismiss.and.returnValue(Promise.resolve());
-        instance.enableBack.and.returnValue(true);
-        instance.isFirst.and.returnValue(false);
-        instance.isLast.and.returnValue(false);
-        instance.pageRef.and.returnValue({});
-        instance.getContent.and.returnValue({});
-        instance.contentRef.and.returnValue(Promise.resolve());
-        instance.hasNavbar.and.returnValue(true);
-        instance.index.and.returnValue(true);
-        instance.subscribe.and.returnValue(Observable.of({}));
-        instance.getNav.and.returnValue(NavControllerMock.instance());
-        instance.getIONContent.and.returnValue({});
+            instance['writeReady'] = {
+                emit(): void {
 
-        instance['writeReady'] = {
-            emit(): void {
+                },
+                subscribe(): any {
 
-            },
-            subscribe(): any {
+                }
+            };
 
-            }
-        };
+            instance['readReady'] = {
+                emit(): void {
 
-        instance['readReady'] = {
-            emit(): void {
+                },
+                subscribe(): any {
 
-            },
-            subscribe(): any {
+                }
+            };
 
-            }
-        };
+            instance['component'] = {};
+            instance['data'] = NavParamsMock.instance();
+            instance['instance'] = {};
+            instance['id'] = '';
 
-        instance['component'] = {};
-        instance['data'] = NavParamsMock.instance();
-        instance['instance'] = {};
-        instance['id'] = '';
+            ViewControllerMock.staticInstance = instance;
+        }
 
-        return instance;
+        return ViewControllerMock.staticInstance;
     }
 }


### PR DESCRIPTION
When calling the `NavControllerMock.instance()` function, this one calls the `ViewControllerMock.instance()` function for a group of returnValues. Unfortunately, this one will also call the `NavControllerMock.instance()` function, resulting in an endless loop which results in a 'Maximum call stack size exceeded' error.

I was able to fix this by storing the first instance that is created as a static variable, and returning it if it is available.