### PR TITLE
Fix typo in NavController's "pangeChanged"

### DIFF
--- a/src/angular/nav-controller.ts
+++ b/src/angular/nav-controller.ts
@@ -6,7 +6,7 @@ export class NavControllerMock {
         let instance: any = jasmine.createSpyObj('NavController', [
             'goToRoot',
             'initPane',
-            'pangeChanged',
+            'paneChanged',
             'push',
             'insert',
             'insertPage',


### PR DESCRIPTION
Hello,

I have come across an issue when using this repository that has saved me tons of time doing my tests :)

It is that it had a typo on `paneChanged` method inside of NavController. That's all.

Thank you for your work.