### PR TITLE
Avoid monkey patching Observable

### DIFF
--- a/src/angular/app.ts
+++ b/src/angular/app.ts
@@ -1,4 +1,5 @@
-import {Observable}           from 'rxjs';
+import {Observable}           from 'rxjs/Observable';
+import {ArrayObservable}      from 'rxjs/observable/ArrayObservable';
 import {NavControllerMock}    from './nav-controller';
 
 export class AppMock {
@@ -19,12 +20,12 @@ export class AppMock {
 
         instance.getRootNav.and.returnValue(navCtrl || NavControllerMock.instance());
         instance.isScrolling.and.returnValue(false);
-        instance.viewDidEnter.and.returnValue(viewObservable || Observable.of(undefined));
-        instance.viewDidLoad.and.returnValue(viewObservable || Observable.of(undefined));
-        instance.viewDidLeave.and.returnValue(viewObservable || Observable.of(undefined));
-        instance.viewWillEnter.and.returnValue(viewObservable || Observable.of(undefined));
-        instance.viewWillUnload.and.returnValue(viewObservable || Observable.of(undefined));
-        instance.viewWillLeave.and.returnValue(viewObservable || Observable.of(undefined));
+        instance.viewDidEnter.and.returnValue(viewObservable || ArrayObservable.of(undefined));
+        instance.viewDidLoad.and.returnValue(viewObservable || ArrayObservable.of(undefined));
+        instance.viewDidLeave.and.returnValue(viewObservable || ArrayObservable.of(undefined));
+        instance.viewWillEnter.and.returnValue(viewObservable || ArrayObservable.of(undefined));
+        instance.viewWillUnload.and.returnValue(viewObservable || ArrayObservable.of(undefined));
+        instance.viewWillLeave.and.returnValue(viewObservable || ArrayObservable.of(undefined));
 
         return instance;
     }

--- a/src/angular/nav-controller.ts
+++ b/src/angular/nav-controller.ts
@@ -1,4 +1,4 @@
-import {Observable} from 'rxjs/Observable';
+import { ArrayObservable }    from 'rxjs/observable/ArrayObservable';
 import { ViewControllerMock } from './view-controller';
 
 export class NavControllerMock {
@@ -84,12 +84,12 @@ export class NavControllerMock {
         instance.length.and.returnValue(0);
         instance.getViews.and.returnValue([]);
         instance.isSwipeBackEnabled.and.returnValue(true);
-        instance.viewDidEnter = Observable.of();
-        instance.viewDidLeave = Observable.of();
-        instance.viewDidLoad = Observable.of();
-        instance.viewWillEnter = Observable.of();
-        instance.viewWillLeave = Observable.of();
-        instance.viewWillUnload = Observable.of();
+        instance.viewDidEnter = ArrayObservable.of();
+        instance.viewDidLeave = ArrayObservable.of();
+        instance.viewDidLoad = ArrayObservable.of();
+        instance.viewWillEnter = ArrayObservable.of();
+        instance.viewWillLeave = ArrayObservable.of();
+        instance.viewWillUnload = ArrayObservable.of();
 
         return instance;
     }

--- a/src/angular/view-controller.ts
+++ b/src/angular/view-controller.ts
@@ -1,4 +1,4 @@
-import { Observable }           from 'rxjs';
+import { ArrayObservable }      from 'rxjs/observable/ArrayObservable';
 import { NavParamsMock }        from './nav-params';
 import { NavControllerMock }    from './nav-controller';
 
@@ -86,12 +86,12 @@ export class ViewControllerMock {
 		instance.length.and.returnValue(0);
 		instance.getViews.and.returnValue([]);
 		instance.isSwipeBackEnabled.and.returnValue(true);
-		instance.viewDidEnter = Observable.of();
-		instance.viewDidLeave = Observable.of();
-		instance.viewDidLoad = Observable.of();
-		instance.viewWillEnter = Observable.of();
-		instance.viewWillLeave = Observable.of();
-		instance.viewWillUnload = Observable.of();
+		instance.viewDidEnter = ArrayObservable.of();
+		instance.viewDidLeave = ArrayObservable.of();
+		instance.viewDidLoad = ArrayObservable.of();
+		instance.viewWillEnter = ArrayObservable.of();
+		instance.viewWillLeave = ArrayObservable.of();
+		instance.viewWillUnload = ArrayObservable.of();
 	}
 
 	public static instance(): any {
@@ -132,12 +132,12 @@ export class ViewControllerMock {
 			'_setIONContentRef'
 		]);
 
-		instance.willEnter.and.returnValue(Observable.of({}));
-		instance.didEnter.and.returnValue(Observable.of({}));
-		instance.willLeave.and.returnValue(Observable.of({}));
-		instance.didLeave.and.returnValue(Observable.of({}));
-		instance.willUnload.and.returnValue(Observable.of({}));
-		instance.didUnload.and.returnValue(Observable.of({}));
+		instance.willEnter.and.returnValue(ArrayObservable.of({}));
+		instance.didEnter.and.returnValue(ArrayObservable.of({}));
+		instance.willLeave.and.returnValue(ArrayObservable.of({}));
+		instance.didLeave.and.returnValue(ArrayObservable.of({}));
+		instance.willUnload.and.returnValue(ArrayObservable.of({}));
+		instance.didUnload.and.returnValue(ArrayObservable.of({}));
 		instance.dismiss.and.returnValue(Promise.resolve());
 		instance.onDidDismiss.and.returnValue(Promise.resolve());
 		instance.onWillDismiss.and.returnValue(Promise.resolve());
@@ -149,7 +149,7 @@ export class ViewControllerMock {
 		instance.contentRef.and.returnValue(Promise.resolve());
 		instance.hasNavbar.and.returnValue(true);
 		instance.index.and.returnValue(true);
-		instance.subscribe.and.returnValue(Observable.of({}));
+		instance.subscribe.and.returnValue(ArrayObservable.of({}));
 		instance.getNav.and.returnValue({});
 		instance.getIONContent.and.returnValue({});
 

--- a/src/native/keyboard.ts
+++ b/src/native/keyboard.ts
@@ -1,4 +1,4 @@
-import { Observable } from 'rxjs/Observable';
+import {EmptyObservable} from 'rxjs/observable/EmptyObservable';
 
 export class KeyboardMock {
     public static instance(): any {
@@ -11,8 +11,8 @@ export class KeyboardMock {
             'onKeyboardHide'
         ]);
 
-        instance.onKeyboardShow.and.returnValue(Observable.empty());
-        instance.onKeyboardHide.and.returnValue(Observable.empty());
+        instance.onKeyboardShow.and.returnValue(EmptyObservable.create());
+        instance.onKeyboardHide.and.returnValue(EmptyObservable.create());
 
         return instance;
     }

--- a/src/native/network.ts
+++ b/src/native/network.ts
@@ -1,4 +1,4 @@
-import { Observable } from 'rxjs/Observable';
+import { EmptyObservable } from 'rxjs/observable/EmptyObservable';
 
 export class NetworkMock {
     public static instance(networkType: string): any {
@@ -11,9 +11,9 @@ export class NetworkMock {
         ]);
         instance.type.and.returnValue(networkType || 'wifi');
         instance.downlinkMax.and.returnValue('42');
-        instance.onChange.and.returnValue(Observable.empty());
-        instance.onDisconnect.and.returnValue(Observable.empty());
-        instance.onConnect.and.returnValue(Observable.empty());
+        instance.onChange.and.returnValue(EmptyObservable.create());
+        instance.onDisconnect.and.returnValue(EmptyObservable.create());
+        instance.onConnect.and.returnValue(EmptyObservable.create());
         return instance;
     }
 }

--- a/src/native/nfc.ts
+++ b/src/native/nfc.ts
@@ -1,4 +1,4 @@
-import { Observable } from 'rxjs/Observable';
+import { EmptyObservable } from 'rxjs/observable/EmptyObservable';
 
 export class NFCMock {
     public static instance(): any {
@@ -20,19 +20,19 @@ export class NFCMock {
             'stringToBytes',
             'bytesToHexString'
         ]);
-        instance.addNdefListener.and.returnValue(Observable.empty());
-        instance.addTagDiscoveredListener.and.returnValue(Observable.empty());
-        instance.addMimeTypeListener.and.returnValue(Observable.empty());
-        instance.addNdefFormatableListener.and.returnValue(Observable.empty());
-        instance.write.and.returnValue(Observable.empty());
-        instance.makeReadyOnly.and.returnValue(Observable.empty());
-        instance.share.and.returnValue(Observable.empty());
-        instance.unshare.and.returnValue(Observable.empty());
-        instance.erase.and.returnValue(Observable.empty());
-        instance.handover.and.returnValue(Observable.empty());
-        instance.stopHandover.and.returnValue(Observable.empty());
-        instance.showSettings.and.returnValue(Observable.empty());
-        instance.enabled.and.returnValue(Observable.empty());
+        instance.addNdefListener.and.returnValue(EmptyObservable.create());
+        instance.addTagDiscoveredListener.and.returnValue(EmptyObservable.create());
+        instance.addMimeTypeListener.and.returnValue(EmptyObservable.create());
+        instance.addNdefFormatableListener.and.returnValue(EmptyObservable.create());
+        instance.write.and.returnValue(EmptyObservable.create());
+        instance.makeReadyOnly.and.returnValue(EmptyObservable.create());
+        instance.share.and.returnValue(EmptyObservable.create());
+        instance.unshare.and.returnValue(EmptyObservable.create());
+        instance.erase.and.returnValue(EmptyObservable.create());
+        instance.handover.and.returnValue(EmptyObservable.create());
+        instance.stopHandover.and.returnValue(EmptyObservable.create());
+        instance.showSettings.and.returnValue(EmptyObservable.create());
+        instance.enabled.and.returnValue(EmptyObservable.create());
         instance.bytesToString.and.returnValue('');
         instance.stringToBytes.and.returnValue([]);
         instance.bytesToHexString.and.returnValue('');

--- a/src/native/three-dee-touch.ts
+++ b/src/native/three-dee-touch.ts
@@ -1,4 +1,5 @@
-import { Observable } from 'rxjs/Observable';
+import { ArrayObservable } from 'rxjs/observable/ArrayObservable';
+import { EmptyObservable } from 'rxjs/observable/EmptyObservable';
 
 export class ThreeDeeTouchMock{
     public static instance(): any {
@@ -11,8 +12,8 @@ export class ThreeDeeTouchMock{
             'disableLinkPreview'
         ]);
         instance.isAvailable.and.returnValue(Promise.resolve(true));
-        instance.watchForTouches.and.returnValue(Observable.of({}));
-        instance.onHomeIconPressed.and.returnValue(Observable.empty());
+        instance.watchForTouches.and.returnValue(ArrayObservable.of({}));
+        instance.onHomeIconPressed.and.returnValue(EmptyObservable.create());
 
         return instance;
     }


### PR DESCRIPTION
After upgrading my project to Ionic 3.9 / Angular 5, it introduced `Observable.empty is not a function` error in `NFCMock`.

I tracked it down to inconsistent imports of `Observable` from `rxjs` and `rxjs/Observable`. The former import includes indirect imports which monkey patch additional functions onto `Observable` such as `empty` and `of`. This affects `Observable` globally, making these functions available at compile time even in files where the latter import is used. At runtime the code without indirect monkey patching imports will fail if those imports aren't done elsewhere.

The issue could be fixed by always using 
```
import {Observable} from 'rxjs';
```
instead of 
```
import {Observable} from 'rxjs/Observable';
```

However, this could still hide potential errors if in new code monkey patched functions would be used without proper imports. This is also [the first reason](https://github.com/ReactiveX/rxjs/blob/master/doc/lettable-operators.md#why) why the library discourages using them. 

To avoid this, I did the opposite - I used the second type of import everywhere. Now, I had to explicitly import all the functions used in each file for the build to succeed.

Of course, it's up to you to decide how you want to have this handled in your library.