### PR TITLE
Fixes typo in NetworkMock

### DIFF
--- a/src/native/network.ts
+++ b/src/native/network.ts
@@ -5,7 +5,7 @@ export class NetworkMock {
         let instance = jasmine.createSpyObj('Network', [
             'type',
             'downlinkMax',
-            'onchange',
+            'onChange',
             'onDisconnect',
             'onConnect',
         ]);


### PR DESCRIPTION
While creating spy object, the method 'onchange' should be 'onChange', to avoid error in line 14